### PR TITLE
Update shebang of shell scripts to use the more portable /usr/bin/env bash

### DIFF
--- a/Auto Heckin Texture Converter/Auto Heckin' Texture Converter.sh
+++ b/Auto Heckin Texture Converter/Auto Heckin' Texture Converter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 # Check for required tools

--- a/EternalExtractor/EternalExtractor.sh
+++ b/EternalExtractor/EternalExtractor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MissingDoomEternal(){
 	printf "'DOOMEternalx64vk.exe' not found!

--- a/EternalModInjectorShell/EternalModInjectorShell.sh
+++ b/EternalModInjectorShell/EternalModInjectorShell.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Colors
 red=$'\e[1;31m'

--- a/ModLoaderToMeath00k/ModLoader_to_MeatHook.sh
+++ b/ModLoaderToMeath00k/ModLoader_to_MeatHook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check for config file
 CreateConfig(){

--- a/idFileDeCompressor_Auto/idFileDeCompressor_Auto.sh
+++ b/idFileDeCompressor_Auto/idFileDeCompressor_Auto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while [[ $# -gt 0 ]]
 do


### PR DESCRIPTION
Not every linux distribution provides a `/bin/bash`. Using `/usr/bin/env bash` works on more systems as `env` will take care of finding where `bash` is.

I've had to do this on my system, others might also benefit from it :)